### PR TITLE
Add support for OCaml 4.12

### DIFF
--- a/run_development_cycle.sh
+++ b/run_development_cycle.sh
@@ -98,7 +98,7 @@ do
             echo "  (public_name General)";
             echo "  (modules General)";
             echo "  (libraries num)";
-            echo "  (flags (:standard -nopervasives -w @A-4-33-44-45-48))";
+            echo "  (flags (:standard -nopervasives -w @A-4-33-44-45-48-67-60))";
             echo ")";
         ) > src/dune
     fi

--- a/src/Reset/CommonHeader.ml
+++ b/src/Reset/CommonHeader.ml
@@ -7,7 +7,7 @@
   #define HAS_Uchar
 #endif
 
-#if OCAML_VERSION >= (4, 4, 0)
+#if OCAML_VERSION >= (4, 4, 0) && OCAML_VERSION < (4, 12, 0)
   #define HAS_Spacetime
 #endif
 

--- a/src/dune
+++ b/src/dune
@@ -170,5 +170,5 @@
   (public_name General)
   (modules General)
   (libraries num)
-  (flags (:standard -nopervasives -w @A-4-33-44-45-48))
+  (flags (:standard -nopervasives -w @A-4-33-44-45-48-67-60))
 )


### PR DESCRIPTION
The `Spacetime` module was removed in 4.12 and new unused module warnings were added (unused-module (60) and unused-functor-param (67))